### PR TITLE
Rely on syn for parsing

### DIFF
--- a/diesel-factories-code-gen/src/lib.rs
+++ b/diesel-factories-code-gen/src/lib.rs
@@ -124,7 +124,7 @@ impl Monkey for syn::Type {
         } = path_segment;
 
         if let syn::PathArguments::AngleBracketed(item) = arguments {
-            let types_we_care_about = item
+            let types_we_care_about: Vec<_> = item
                 .args
                 .iter()
                 .filter_map(|token| {
@@ -134,7 +134,7 @@ impl Monkey for syn::Type {
                         return None;
                     }
                 })
-                .collect::<Vec<&syn::Type>>();
+                .collect();
             if types_we_care_about.len() != 2 {
                 panic!("should only have model and factory");
             }

--- a/diesel-factories-code-gen/src/lib.rs
+++ b/diesel-factories-code-gen/src/lib.rs
@@ -52,11 +52,11 @@ struct DeriveData {
     tokens: TokenStream,
 }
 
-trait MonkeyPathSegment {
+trait PathSegmentExtension {
     fn normalize_lifetime_names(&self) -> TokenStream;
 }
 
-impl MonkeyPathSegment for syn::PathSegment {
+impl PathSegmentExtension for syn::PathSegment {
     fn normalize_lifetime_names(&self) -> TokenStream {
         if let syn::PathArguments::AngleBracketed(_args) = &self.arguments {
             let ident = &self.ident;
@@ -69,7 +69,7 @@ impl MonkeyPathSegment for syn::PathSegment {
     }
 }
 
-trait MonkeyType {
+trait TypeExtension {
     fn to_string(&self) -> String;
     fn extract_outermost_type(&self) -> &syn::PathSegment;
     fn is_inside_option(&self) -> bool;
@@ -79,7 +79,7 @@ trait MonkeyType {
     fn parse_association_type(&self) -> Option<Association>;
 }
 
-impl MonkeyType for syn::Type {
+impl TypeExtension for syn::Type {
     fn parse_association_type(&self) -> Option<Association> {
         let is_option = self.is_inside_option();
 

--- a/diesel-factories-code-gen/src/lib.rs
+++ b/diesel-factories-code-gen/src/lib.rs
@@ -72,7 +72,7 @@ impl MonkeyPathSegment for syn::PathSegment {
 trait MonkeyType {
     fn to_string(&self) -> String;
     fn extract_outermost_type(&self) -> &syn::PathSegment;
-    fn option_detected(&self) -> bool;
+    fn is_inside_option(&self) -> bool;
     fn extract_outermost_non_optional(&self) -> Option<&syn::PathSegment>;
     fn extract_model_and_factory(&self) -> Option<(TokenStream, TokenStream)>;
     fn is_association_field(&self) -> bool;
@@ -81,7 +81,7 @@ trait MonkeyType {
 
 impl MonkeyType for syn::Type {
     fn parse_association_type(&self) -> Option<Association> {
-        let is_option = self.option_detected();
+        let is_option = self.is_inside_option();
 
         let (model, factory) = if_let_or_none!(Some, self.extract_model_and_factory());
         Some(Association {
@@ -118,12 +118,12 @@ impl MonkeyType for syn::Type {
         }
     }
 
-    fn option_detected(&self) -> bool {
+    fn is_inside_option(&self) -> bool {
         self.extract_outermost_type().ident.to_string() == "Option"
     }
 
     fn extract_outermost_non_optional(&self) -> Option<&syn::PathSegment> {
-        if !self.option_detected() {
+        if !self.is_inside_option() {
             return Some(self.extract_outermost_type());
         } else {
             let item = if_let_or_none!(

--- a/diesel-factories-code-gen/src/lib.rs
+++ b/diesel-factories-code-gen/src/lib.rs
@@ -262,8 +262,8 @@ impl DeriveData {
 
             let model = association.model;
             let other_factory = association.factory;
-
-            let other_factory_without_lifetime = other_factory.to_string().replace(" < 'a >", "");
+            let temp = other_factory.to_string();
+            let other_factory_without_lifetime = temp.split(" <").next().unwrap();
             let trait_name = ident(&format!(
                 "Set{}On{}For{}",
                 other_factory_without_lifetime, factory, camel_field_name

--- a/diesel-factories-code-gen/src/lib.rs
+++ b/diesel-factories-code-gen/src/lib.rs
@@ -118,7 +118,10 @@ impl Monkey for syn::Type {
 
     fn extract_model_and_factory(&self) -> Option<(TokenStream, TokenStream)> {
         let path_segment = self.extract_outermost_non_optional();
-        let syn::PathSegment { ident, arguments } = path_segment;
+        let syn::PathSegment {
+            ident: _,
+            arguments,
+        } = path_segment;
 
         if let syn::PathArguments::AngleBracketed(item) = arguments {
             let types_we_care_about = item
@@ -145,7 +148,7 @@ impl Monkey for syn::Type {
             let factory = factory_type.extract_outermost_type();
             let model_tokens;
             let factory_tokens;
-            if let syn::PathArguments::AngleBracketed(args) = &model.arguments {
+            if let syn::PathArguments::AngleBracketed(_args) = &model.arguments {
                 let ident = &model.ident;
                 model_tokens = quote! {
                     #ident<'z>
@@ -153,7 +156,7 @@ impl Monkey for syn::Type {
             } else {
                 model_tokens = model.into_token_stream();
             }
-            if let syn::PathArguments::AngleBracketed(args) = &factory.arguments {
+            if let syn::PathArguments::AngleBracketed(_args) = &factory.arguments {
                 let ident = &factory.ident;
                 factory_tokens = quote! {
                     #ident<'z>

--- a/diesel-factories-code-gen/src/lib.rs
+++ b/diesel-factories-code-gen/src/lib.rs
@@ -158,13 +158,16 @@ impl MonkeyType for syn::Type {
             if types_we_care_about.len() != 2 {
                 return None;
             }
-            let model_type = types_we_care_about.first().unwrap();
-            let model = model_type.extract_outermost_type();
-            let model_tokens = model.normalize_lifetime_names();
-
-            let factory_type = types_we_care_about.last().unwrap();
-            let factory = factory_type.extract_outermost_type();
-            let factory_tokens = factory.normalize_lifetime_names();
+            let model_tokens = types_we_care_about
+                .first()
+                .unwrap()
+                .extract_outermost_type()
+                .normalize_lifetime_names();
+            let factory_tokens = types_we_care_about
+                .last()
+                .unwrap()
+                .extract_outermost_type()
+                .normalize_lifetime_names();
             return Some((model_tokens, factory_tokens));
         } else {
             None

--- a/diesel-factories-code-gen/src/lib.rs
+++ b/diesel-factories-code-gen/src/lib.rs
@@ -332,24 +332,21 @@ impl DeriveData {
 
     fn option_detected(&self, ty: &syn::Type) -> bool {
         if let Path(syn::TypePath { qself: _, path }) = ty.clone() {
-            if let syn::Path {
+            let syn::Path {
                 leading_colon: _,
                 segments,
-            } = path
-            {
-                let path_segment = segments.last().unwrap().value().clone();
-                if path_segment.ident.to_string() == "Option" {
-                    return true;
-                // println!("Optional detected {}", self.type_to_string(ty))
-                } else {
-                    return false;
-                    // println!("Optional NOT detected {}", self.type_to_string(ty))
-                }
+            } = path;
+
+            let path_segment = segments.last().unwrap().value().clone();
+            if path_segment.ident.to_string() == "Option" {
+                return true;
+            // println!("Optional detected {}", self.type_to_string(ty))
             } else {
-                panic!("wut");
+                return false;
+                // println!("Optional NOT detected {}", self.type_to_string(ty))
             }
         } else {
-            panic!("hjer");
+            panic!("Expected a TypePath here");
         }
     }
 

--- a/diesel-factories-code-gen/src/lib.rs
+++ b/diesel-factories-code-gen/src/lib.rs
@@ -125,9 +125,8 @@ impl Monkey for syn::Type {
 
         if let syn::PathArguments::AngleBracketed(item) = arguments {
             let types_we_care_about = item
-                .clone()
                 .args
-                .into_iter()
+                .iter()
                 .filter_map(|token| {
                     if let syn::GenericArgument::Type(extracted) = token {
                         return Some(extracted);
@@ -135,7 +134,7 @@ impl Monkey for syn::Type {
                         return None;
                     }
                 })
-                .collect::<Vec<syn::Type>>();
+                .collect::<Vec<&syn::Type>>();
             if types_we_care_about.len() != 2 {
                 panic!("should only have model and factory");
             }

--- a/diesel-factories-code-gen/src/lib.rs
+++ b/diesel-factories-code-gen/src/lib.rs
@@ -42,6 +42,19 @@ struct DeriveData {
     tokens: TokenStream,
 }
 
+trait ToString {
+    fn to_string(&self) -> String;
+}
+
+impl ToString for syn::Type {
+    fn to_string(&self) -> String {
+        use quote::ToTokens;
+        let mut tokenized = quote! {};
+        self.to_tokens(&mut tokenized);
+        tokenized.to_string()
+    }
+}
+
 impl DeriveData {
     fn new(input: DeriveInput, options: Options) -> Self {
         Self {
@@ -188,15 +201,6 @@ impl DeriveData {
         }
     }
 
-    // TODO implement on syn::Type
-    fn type_to_string(&self, ty: &syn::Type) -> String {
-        use quote::ToTokens;
-
-        let mut tokenized = quote! {};
-        ty.to_tokens(&mut tokenized);
-        tokenized.to_string()
-    }
-
     fn builder_methods(&self) -> Vec<TokenStream> {
         self.struct_fields()
             .filter_map(|field| self.builder_method(field))
@@ -256,7 +260,7 @@ impl DeriveData {
                 writeln!(s, "Association<'a, Model, Factory<'a>>").unwrap();
                 writeln!(s, "Option<Association<'a, Model, Factory<'a>>>").unwrap();
                 writeln!(s).unwrap();
-                writeln!(s, "Got\n{}", self.type_to_string(&field.ty)).unwrap();
+                writeln!(s, "Got\n{}", &field.ty.to_string()).unwrap();
                 panic!("{}", s);
             });
 
@@ -386,8 +390,8 @@ impl DeriveData {
                 .collect::<Vec<syn::Type>>();
             if types_we_care_about.len() != 2 {
                 dbg!(item);
-                dbg!(self.type_to_string(ty));
-                dbg!(self.type_to_string(types_we_care_about.first().unwrap()));
+                dbg!(ty.to_string());
+                dbg!(types_we_care_about.first().unwrap().to_string());
                 panic!("should only have model and factory");
             }
             let model_type = types_we_care_about.first().unwrap();

--- a/diesel-factories-code-gen/src/lib.rs
+++ b/diesel-factories-code-gen/src/lib.rs
@@ -340,10 +340,8 @@ impl DeriveData {
             let path_segment = segments.last().unwrap().value().clone();
             if path_segment.ident.to_string() == "Option" {
                 return true;
-            // println!("Optional detected {}", self.type_to_string(ty))
             } else {
                 return false;
-                // println!("Optional NOT detected {}", self.type_to_string(ty))
             }
         } else {
             panic!("Expected a TypePath here");

--- a/diesel-factories-code-gen/src/lib.rs
+++ b/diesel-factories-code-gen/src/lib.rs
@@ -45,9 +45,9 @@ struct DeriveData {
 
 trait Monkey {
     fn to_string(&self) -> String;
-    fn extract_outermost_type<'a>(&'a self) -> &'a syn::PathSegment;
+    fn extract_outermost_type(&self) -> &syn::PathSegment;
     fn option_detected(&self) -> bool;
-    fn extract_outermost_non_optional<'a>(&'a self) -> &'a syn::PathSegment;
+    fn extract_outermost_non_optional(&self) -> &syn::PathSegment;
     fn extract_model_and_factory(&self) -> Option<(TokenStream, TokenStream)>;
     fn is_association_field(&self) -> bool;
     fn parse_association_type(&self) -> Option<Association>;
@@ -79,7 +79,7 @@ impl Monkey for syn::Type {
         tokenized.to_string()
     }
 
-    fn extract_outermost_type<'a>(&'a self) -> &'a syn::PathSegment {
+    fn extract_outermost_type(&self) -> &syn::PathSegment {
         if let Path(syn::TypePath { qself: _, path }) = self {
             let syn::Path {
                 leading_colon: _,
@@ -96,7 +96,7 @@ impl Monkey for syn::Type {
         self.extract_outermost_type().ident.to_string() == "Option"
     }
 
-    fn extract_outermost_non_optional<'a>(&'a self) -> &'a syn::PathSegment {
+    fn extract_outermost_non_optional(&self) -> &syn::PathSegment {
         if !self.option_detected() {
             return self.extract_outermost_type();
         } else {

--- a/diesel-factories-code-gen/src/lib.rs
+++ b/diesel-factories-code-gen/src/lib.rs
@@ -104,7 +104,7 @@ impl Monkey for syn::Type {
                 &self.extract_outermost_type().arguments
             {
                 if let syn::GenericArgument::Type(unwrapped_type) =
-                    &item.args.last().unwrap().value().clone()
+                    &item.args.last().unwrap().value()
                 {
                     return &unwrapped_type.extract_outermost_type();
                 } else {
@@ -137,9 +137,6 @@ impl Monkey for syn::Type {
                 })
                 .collect::<Vec<syn::Type>>();
             if types_we_care_about.len() != 2 {
-                dbg!(item);
-                dbg!(self.to_string());
-                dbg!(types_we_care_about.first().unwrap().to_string());
                 panic!("should only have model and factory");
             }
             let model_type = types_we_care_about.first().unwrap();
@@ -148,6 +145,7 @@ impl Monkey for syn::Type {
             let factory = factory_type.extract_outermost_type();
             let model_tokens;
             let factory_tokens;
+            // FIXME dedupe this code
             if let syn::PathArguments::AngleBracketed(_args) = &model.arguments {
                 let ident = &model.ident;
                 model_tokens = quote! {
@@ -156,6 +154,7 @@ impl Monkey for syn::Type {
             } else {
                 model_tokens = model.into_token_stream();
             }
+            // FIXME dedupe this code
             if let syn::PathArguments::AngleBracketed(_args) = &factory.arguments {
                 let ident = &factory.ident;
                 factory_tokens = quote! {

--- a/diesel-factories/tests/integration_test.rs
+++ b/diesel-factories/tests/integration_test.rs
@@ -63,15 +63,15 @@ struct City {
     table = "crate::schema::users",
     connection = "diesel::pg::PgConnection"
 )]
-struct UserFactory<'a> {
+struct UserFactory<'b> {
     pub name: String,
     pub age: i32,
-    pub country: std::option::Option<diesel_factories::Association<'a, Country, CountryFactory>>,
-    pub home_city: Option<diesel_factories::Association<'a, City, CityFactory<'a>>>,
-    pub current_city: Option<Association<'a, City, CityFactory<'a>>>,
+    pub country: std::option::Option<diesel_factories::Association<'b, Country, CountryFactory>>,
+    pub home_city: Option<diesel_factories::Association<'b, City, CityFactory<'b>>>,
+    pub current_city: Option<Association<'b, City, CityFactory<'b>>>,
 }
 
-impl<'a> Default for UserFactory<'a> {
+impl<'b> Default for UserFactory<'b> {
     fn default() -> Self {
         Self {
             name: "Bob".into(),
@@ -99,12 +99,12 @@ impl Default for CountryFactory {
 
 #[derive(Clone, Factory)]
 #[factory(model = "City", table = "crate::schema::cities")]
-struct CityFactory<'a> {
+struct CityFactory<'b> {
     pub name: String,
-    pub country: Association<'a, Country, CountryFactory>,
+    pub country: Association<'b, Country, CountryFactory>,
 }
 
-impl<'a> Default for CityFactory<'a> {
+impl<'b> Default for CityFactory<'b> {
     fn default() -> Self {
         Self {
             name: "Copenhagen".into(),

--- a/diesel-factories/tests/integration_test.rs
+++ b/diesel-factories/tests/integration_test.rs
@@ -29,6 +29,8 @@ mod schema {
         cities (id) {
             id -> Integer,
             name -> Text,
+            team_association -> Text,
+            association_label -> Text,
             country_id -> Integer,
         }
     }
@@ -54,6 +56,8 @@ struct Country {
 struct City {
     pub id: i32,
     pub name: String,
+    pub team_association: String,
+    pub association_label: String,
     pub country_id: i32,
 }
 
@@ -101,6 +105,8 @@ impl Default for CountryFactory {
 #[factory(model = "City", table = "crate::schema::cities")]
 struct CityFactory<'b> {
     pub name: String,
+    pub team_association: String,
+    pub association_label: String,
     pub country: Association<'b, Country, CountryFactory>,
 }
 
@@ -108,6 +114,8 @@ impl<'b> Default for CityFactory<'b> {
     fn default() -> Self {
         Self {
             name: "Copenhagen".into(),
+            team_association: "teamfive".into(),
+            association_label: "thebest".into(),
             country: Association::default(),
         }
     }

--- a/diesel-factories/tests/integration_test.rs
+++ b/diesel-factories/tests/integration_test.rs
@@ -66,7 +66,7 @@ struct City {
 struct UserFactory<'a> {
     pub name: String,
     pub age: i32,
-    pub country: Option<Association<'a, Country, CountryFactory>>,
+    pub country: std::option::Option<diesel_factories::Association<'a, Country, CountryFactory>>,
     pub home_city: Option<Association<'a, City, CityFactory<'a>>>,
     pub current_city: Option<Association<'a, City, CityFactory<'a>>>,
 }

--- a/diesel-factories/tests/integration_test.rs
+++ b/diesel-factories/tests/integration_test.rs
@@ -67,7 +67,7 @@ struct UserFactory<'a> {
     pub name: String,
     pub age: i32,
     pub country: std::option::Option<diesel_factories::Association<'a, Country, CountryFactory>>,
-    pub home_city: Option<Association<'a, City, CityFactory<'a>>>,
+    pub home_city: Option<diesel_factories::Association<'a, City, CityFactory<'a>>>,
     pub current_city: Option<Association<'a, City, CityFactory<'a>>>,
 }
 

--- a/migrations/2019-05-10-072830_cities/up.sql
+++ b/migrations/2019-05-10-072830_cities/up.sql
@@ -1,7 +1,9 @@
 CREATE TABLE cities (
   id SERIAL PRIMARY KEY,
   name TEXT NOT NULL,
-  country_id integer NOT NULL
+  country_id integer NOT NULL,
+  team_association TEXT NULL,
+  association_label TEXT NULL
 );
 
 ALTER TABLE users


### PR DESCRIPTION
I'm pretty sure relying on Syn for this is going to be much more robust than regexes. Actually writing the logic to destructure the tokens syn gives us isn't so trivial, but isn't too difficult.

I've done my best to throw weird tokens at this macro in the tests, and it seems robust against them. Going to spend a bit of time trying to refactor the code; any suggestions for improvements would be appreciated.

Should close https://github.com/davidpdrsn/diesel-factories/issues/10 and https://github.com/davidpdrsn/diesel-factories/issues/9 and https://github.com/davidpdrsn/diesel-factories/issues/8 .