### PR TITLE
Change model_type to accept a path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ### Added
 
-N/A
+- Support for using path names for models.
 
 ### Changed
 

--- a/diesel-factories-code-gen/src/lib.rs
+++ b/diesel-factories-code-gen/src/lib.rs
@@ -38,7 +38,7 @@ pub fn derive_factory(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 #[derive(FromDeriveInput, Debug)]
 #[darling(attributes(factory), forward_attrs(doc, cfg, allow))]
 struct Options {
-    model: syn::Ident,
+    model: syn::Path,
     #[darling(default)]
     connection: Option<syn::Path>,
     #[darling(default)]
@@ -99,7 +99,6 @@ impl TypeExtension for syn::Type {
     }
 
     fn to_string(&self) -> String {
-        use quote::ToTokens;
         let mut tokenized = quote! {};
         self.to_tokens(&mut tokenized);
         tokenized.to_string()
@@ -259,7 +258,7 @@ impl DeriveData {
         &self.input.ident
     }
 
-    fn model_type(&self) -> &syn::Ident {
+    fn model_type(&self) -> &syn::Path {
         &self.options.model
     }
 

--- a/diesel-factories-code-gen/src/lib.rs
+++ b/diesel-factories-code-gen/src/lib.rs
@@ -52,23 +52,6 @@ struct DeriveData {
     tokens: TokenStream,
 }
 
-trait PathSegmentExtension {
-    fn normalize_lifetime_names(&self) -> TokenStream;
-}
-
-impl PathSegmentExtension for syn::PathSegment {
-    fn normalize_lifetime_names(&self) -> TokenStream {
-        if let syn::PathArguments::AngleBracketed(_args) = &self.arguments {
-            let ident = &self.ident;
-            return quote! {
-                #ident<'z>
-            };
-        } else {
-            return self.into_token_stream();
-        }
-    }
-}
-
 trait TypeExtension {
     fn to_string(&self) -> String;
     fn extract_outermost_type(&self) -> &syn::PathSegment;
@@ -77,6 +60,7 @@ trait TypeExtension {
     fn extract_model_and_factory(&self) -> Option<(TokenStream, TokenStream)>;
     fn is_association_field(&self) -> bool;
     fn parse_association_type(&self) -> Option<Association>;
+    fn normalize_lifetime_names(&self) -> TokenStream;
 }
 
 impl TypeExtension for syn::Type {
@@ -137,6 +121,28 @@ impl TypeExtension for syn::Type {
         }
     }
 
+    fn normalize_lifetime_names(&self) -> TokenStream {
+        if let syn::Type::Path(syn::TypePath { qself: _, path }) = self {
+            let syn::Path {
+                leading_colon: _,
+                segments,
+            } = path;
+
+            let seg = segments.last().unwrap();
+            let seg_value = seg.value();
+            if let syn::PathArguments::AngleBracketed(_args) = &seg_value.arguments {
+                let ident = &seg_value.ident;
+                return quote! {
+                    #ident<'z>
+                };
+            } else {
+                return self.into_token_stream();
+            }
+        } else {
+            panic!("Expected a TypePath here");
+        }
+    }
+
     fn extract_model_and_factory(&self) -> Option<(TokenStream, TokenStream)> {
         let path_segment;
         match self.extract_outermost_non_optional() {
@@ -163,12 +169,10 @@ impl TypeExtension for syn::Type {
         let model_tokens = types_we_care_about
             .first()
             .unwrap()
-            .extract_outermost_type()
             .normalize_lifetime_names();
         let factory_tokens = types_we_care_about
             .last()
             .unwrap()
-            .extract_outermost_type()
             .normalize_lifetime_names();
         return Some((model_tokens, factory_tokens));
     }

--- a/diesel-factories/tests/path_name_models.rs
+++ b/diesel-factories/tests/path_name_models.rs
@@ -1,0 +1,91 @@
+#[macro_use]
+extern crate diesel;
+
+use diesel::{pg::PgConnection, prelude::*};
+use diesel_factories::{Association, Factory};
+
+mod models {
+    pub mod schema {
+        table! {
+            users (id) {
+                id -> Integer,
+                name -> Text,
+                age -> Integer,
+                country_id -> Nullable<Integer>,
+                home_city_id -> Nullable<Integer>,
+                current_city_id -> Nullable<Integer>,
+            }
+        }
+
+        table! {
+            countries (id) {
+                id -> Integer,
+                name -> Text,
+            }
+        }
+
+        table! {
+            cities (id) {
+                id -> Integer,
+                name -> Text,
+                country_id -> Integer,
+            }
+        }
+    }
+
+    #[derive(Queryable, Clone)]
+    pub struct User {
+        pub id: i32,
+        pub name: String,
+        pub age: i32,
+        pub country_id: Option<i32>,
+        pub home_city_id: Option<i32>,
+        pub current_city_id: Option<i32>,
+    }
+
+    #[derive(Clone, Queryable)]
+    pub struct City {
+        pub id: i32,
+        pub name: String,
+        pub country_id: i32,
+    }
+
+    #[derive(Clone, Queryable)]
+    pub struct Country {
+        pub id: i32,
+        pub name: String,
+    }
+}
+
+#[derive(Clone, Factory)]
+#[factory(
+    model = "crate::models::Country",
+    table = "crate::models::schema::countries"
+)]
+struct CountryFactory {
+    pub name: String,
+}
+
+impl Default for CountryFactory {
+    fn default() -> Self {
+        Self {
+            name: "Denmark".into(),
+        }
+    }
+}
+
+#[derive(Clone, Factory)]
+#[factory(model = "crate::models::City", table = "crate::models::schema::cities")]
+struct CityFactory<'a> {
+    pub name: String,
+    pub country: Association<'a, crate::models::Country, CountryFactory>,
+}
+
+impl<'a> Default for CityFactory<'a> {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            country: Association::default(),
+        }
+    }
+}


### PR DESCRIPTION
Changes `model_type` to accept a path so we can do:

```rust
#[factory(
  model="cities::City",
...
)]
```

in addition to

```rust
#[factory(
  model="City",
...
)]
```