### PR TITLE
Add id_name option to derive macro to allow alternative primary key column names

### DIFF
--- a/diesel-factories-code-gen/src/lib.rs
+++ b/diesel-factories-code-gen/src/lib.rs
@@ -44,6 +44,8 @@ struct Options {
     connection: Option<syn::Path>,
     #[darling(default)]
     id: Option<syn::Ident>,
+    #[darling(default)]
+    id_name: Option<syn::Ident>,
     table: syn::Path,
 }
 
@@ -200,6 +202,7 @@ impl DeriveData {
         let factory = self.factory_name();
         let generics = self.factory_generics();
         let model_type = self.model_type();
+        let id_name = self.id_name();
         let id_type = self.id_type();
         let connection_type = self.connection_type();
         let table_path = self.table_path();
@@ -220,7 +223,7 @@ impl DeriveData {
                 }
 
                 fn id_for_model(model: &Self::Model) -> &Self::Id {
-                    &model.id
+                    &model.#id_name
                 }
             }
         };
@@ -275,6 +278,14 @@ impl DeriveData {
             .as_ref()
             .map(|inner| quote! { #inner })
             .unwrap_or_else(|| quote! { i32 })
+    }
+
+    fn id_name(&self) -> TokenStream {
+        self.options
+            .id_name
+            .as_ref()
+            .map(|inner| quote! { #inner })
+            .unwrap_or(quote! { id })
     }
 
     fn connection_type(&self) -> TokenStream {

--- a/diesel-factories/src/lib.rs
+++ b/diesel-factories/src/lib.rs
@@ -12,10 +12,11 @@
 //! use diesel::{pg::PgConnection, prelude::*};
 //!
 //! // Tell Diesel what our schema is
+//! // Note unusual primary key name - see options for derive macro.
 //! mod schema {
 //!     table! {
-//!         countries (id) {
-//!             id -> Integer,
+//!         countries (identity) {
+//!             identity -> Integer,
 //!             name -> Text,
 //!         }
 //!     }
@@ -72,7 +73,7 @@
 //! // The same setup, but for `Country`
 //! #[derive(Clone, Queryable)]
 //! struct Country {
-//!     pub id: i32,
+//!     pub identity: i32,
 //!     pub name: String,
 //! }
 //!
@@ -82,6 +83,7 @@
 //!     table = "crate::schema::countries",
 //!     connection = "diesel::pg::PgConnection",
 //!     id = "i32",
+//!     id_name = "identity",
 //! )]
 //! struct CountryFactory {
 //!     pub name: String,
@@ -176,7 +178,7 @@
 //! fn find_country_by_id(input: i32, con: &PgConnection) -> Country {
 //!     use crate::schema::countries::dsl::*;
 //!     countries
-//!         .filter(id.eq(&input))
+//!         .filter(identity.eq(&input))
 //!         .first::<Country>(con)
 //!         .unwrap()
 //! }

--- a/diesel-factories/tests/compile_pass/alternative_pk_name.rs
+++ b/diesel-factories/tests/compile_pass/alternative_pk_name.rs
@@ -1,0 +1,37 @@
+#![allow(proc_macro_derive_resolution_fallback)]
+
+#[macro_use]
+extern crate diesel;
+
+use diesel::{pg::PgConnection, prelude::*};
+use diesel_factories::{Association, Factory};
+
+mod schema {
+    table! {
+        users (identity) {
+            identity -> Integer,
+        }
+    }
+}
+
+#[derive(Queryable, Clone)]
+struct User {
+    pub identity: i32,
+}
+
+#[derive(Clone, Factory)]
+#[factory(
+    model = "User",
+    table = "crate::schema::users",
+    connection = "diesel::pg::PgConnection",
+    id_name = "identity"
+)]
+struct UserFactory {}
+
+impl Default for UserFactory {
+    fn default() -> Self {
+        Self {}
+    }
+}
+
+fn main() {}

--- a/diesel-factories/tests/integration_test.rs
+++ b/diesel-factories/tests/integration_test.rs
@@ -19,8 +19,8 @@ mod schema {
     }
 
     table! {
-        countries (id) {
-            id -> Integer,
+        countries (identity) {
+            identity -> Integer,
             name -> Text,
         }
     }
@@ -48,7 +48,7 @@ struct User {
 
 #[derive(Queryable, Clone)]
 struct Country {
-    pub id: i32,
+    pub identity: i32,
     pub name: String,
 }
 
@@ -88,7 +88,11 @@ impl<'b> Default for UserFactory<'b> {
 }
 
 #[derive(Clone, Factory)]
-#[factory(model = "Country", table = "crate::schema::countries")]
+#[factory(
+    model = "Country",
+    table = "crate::schema::countries",
+    id_name = "identity"
+)]
 struct CountryFactory {
     pub name: String,
 }
@@ -183,7 +187,7 @@ fn count_countries(con: &PgConnection) -> i64 {
 fn find_country_by_id(input: i32, con: &PgConnection) -> Country {
     use crate::schema::countries::dsl::*;
     countries
-        .filter(id.eq(&input))
+        .filter(identity.eq(&input))
         .first::<Country>(con)
         .unwrap()
 }

--- a/migrations/2020-04-14-095023_change_pk_colname/down.sql
+++ b/migrations/2020-04-14-095023_change_pk_colname/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE countries RENAME COLUMN identity TO id;

--- a/migrations/2020-04-14-095023_change_pk_colname/up.sql
+++ b/migrations/2020-04-14-095023_change_pk_colname/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE countries RENAME COLUMN id TO identity;


### PR DESCRIPTION
This PR adds an additional option to the `factory` derive macro to allow columns with names other than `id` to be used as the model's ID.

Tests pass locally but not on CI, seemingly because Postgres is missing in CI - not sure why that is!