### PR TITLE
derive: Respect id_name option for associations

### DIFF
--- a/diesel-factories-code-gen/src/lib.rs
+++ b/diesel-factories-code-gen/src/lib.rs
@@ -348,7 +348,7 @@ impl DeriveData {
             .unwrap_or_else(|| panic!("Factory can only be derived for named fields"));
 
         if let Some(association) = field.ty.parse_association_type() {
-            let foreign_key_field = ident(&format!("{}_id", name));
+            let foreign_key_field = ident(&format!("{}_{}", name, self.id_name()));
             if association.is_option {
                 quote! {
                     {

--- a/diesel-factories/tests/compile_pass/alternative_fk_name.rs
+++ b/diesel-factories/tests/compile_pass/alternative_fk_name.rs
@@ -1,0 +1,69 @@
+#![allow(proc_macro_derive_resolution_fallback)]
+
+#[macro_use]
+extern crate diesel;
+
+use diesel::{pg::PgConnection, prelude::*};
+use diesel_factories::{Association, Factory};
+
+mod schema {
+    table! {
+        countries (identity) {
+            identity -> Integer,
+            name -> Text,
+        }
+    }
+
+    table! {
+        cities (identity) {
+            identity -> Integer,
+            name -> Text,
+            country_identity -> Integer,
+        }
+    }
+}
+
+#[derive(Clone, Queryable)]
+pub struct City {
+    pub identity: i32,
+    pub name: String,
+    pub country_identity: i32,
+}
+
+#[derive(Clone, Queryable)]
+pub struct Country {
+    pub identity: i32,
+    pub name: String,
+}
+
+#[derive(Clone, Factory)]
+#[factory(model = "Country", table = "schema::countries", id_name = "identity")]
+struct CountryFactory {
+    pub name: String,
+}
+
+impl Default for CountryFactory {
+    fn default() -> Self {
+        Self {
+            name: "Denmark".into(),
+        }
+    }
+}
+
+#[derive(Clone, Factory)]
+#[factory(model = "City", table = "schema::cities", id_name = "identity")]
+struct CityFactory<'a> {
+    pub name: String,
+    pub country: Association<'a, Country, CountryFactory>,
+}
+
+impl<'a> Default for CityFactory<'a> {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            country: Association::default(),
+        }
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
This allows having a foreign key named e.g.  `model_key` rather than `model_id` when the `id_name` option is set to `key`.

This is a slight fix for https://github.com/davidpdrsn/diesel-factories/pull/18