### PR TITLE
add support for having a model without a single primary key ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,37 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## Unreleased
 
-Nothing yet.
+Add support for tables with no primary key (e.g. a joined PK between columns)
+
+```rust
+mod schema {
+    table! {
+        users (id) {
+            id -> Integer,
+        }
+    }
+    
+    table! {
+        city(id) {
+            id -> Integer,
+        }
+    }
+    
+    table! {
+        visited_cities (user_id, city_id) {
+            user_id -> Int4,
+            city_id -> Int4,
+        }
+    }
+}
+
+#[derive(Clone, Factory)]
+#[factory(model = VisitedCity, table = crate::schema::visited_cities, no_id)]
+struct VisitedCityFactory<'a> {
+    pub user: Association<'a, User, UserFactory>,
+    pub city: Association<'a, City, CityFactory>,
+}
+```
 
 ## 2.0.0
 

--- a/diesel-factories/src/lib.rs
+++ b/diesel-factories/src/lib.rs
@@ -464,6 +464,22 @@ impl<'a, Model, Factory> Association<'a, Model, Factory> {
     pub fn new_factory(inner: Factory) -> Self {
         Association::Factory(inner)
     }
+
+    #[doc(hidden)]
+    pub fn model(&self) -> Option<&Model> {
+        match self {
+            Association::Model(x) => Some(x),
+            _ => None,
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn factory(&self) -> Option<&Factory> {
+        match self {
+            Association::Factory(x) => Some(x),
+            _ => None,
+        }
+    }
 }
 
 impl<M, F> Association<'_, M, F>

--- a/diesel-factories/tests/compile_pass/no_pk.rs
+++ b/diesel-factories/tests/compile_pass/no_pk.rs
@@ -1,0 +1,197 @@
+#![allow(proc_macro_derive_resolution_fallback, unused_imports)]
+
+#[macro_use]
+extern crate diesel;
+
+use diesel::{pg::PgConnection, prelude::*};
+use diesel_factories::{Association, Factory};
+
+mod schema {
+    table! {
+        users (id) {
+            id -> Integer,
+            name -> Text,
+            age -> Integer,
+            email -> Nullable<Text>,
+            country_id -> Integer,
+            home_country_id -> Nullable<Integer>,
+        }
+    }
+
+    table! {
+        countries (identity) {
+            identity -> Integer,
+            name -> Text,
+        }
+    }
+
+    table! {
+        cities (id) {
+            id -> Integer,
+            name -> Text,
+            team_association -> Text,
+            association_label -> Text,
+            country_id -> Integer,
+        }
+    }
+
+    table! {
+        visited_cities (user_id, city_id) {
+            user_id -> Integer,
+            city_id -> Integer,
+        }
+    }
+}
+
+#[derive(Queryable, Clone)]
+struct User {
+    pub id: i32,
+    pub name: String,
+    pub age: i32,
+    pub email: Option<String>,
+    pub country_id: i32,
+    pub home_country_id: Option<i32>,
+}
+
+#[derive(Clone, Factory)]
+#[factory(
+model = User,
+table = crate::schema::users,
+connection = diesel::pg::PgConnection,
+)]
+struct UserFactory<'a> {
+    pub name: String,
+    pub age: i32,
+    pub email: Option<String>,
+    pub country: Association<'a, Country, CountryFactory>,
+    pub home_country: Option<Association<'a, Country, CountryFactory>>,
+}
+
+impl Default for UserFactory<'_> {
+    fn default() -> Self {
+        Self {
+            name: "Bob".into(),
+            age: 30,
+            email: None,
+            country: Default::default(),
+            home_country: Default::default(),
+        }
+    }
+}
+
+#[derive(Queryable, Clone)]
+struct Country {
+    pub id: i32,
+    pub name: String,
+}
+
+#[derive(Clone, Factory)]
+#[factory(
+model = Country,
+table = crate::schema::countries,
+)]
+struct CountryFactory {
+    pub name: String,
+}
+
+impl Default for CountryFactory {
+    fn default() -> Self {
+        Self {
+            name: "Denmark".into(),
+        }
+    }
+}
+
+#[derive(Queryable, Clone)]
+struct City {
+    pub id: i32,
+    pub name: String,
+    pub team_association: String,
+    pub association_label: String,
+    pub country_id: i32,
+}
+
+#[derive(Clone, Factory)]
+#[factory(model = City, table = crate::schema::cities)]
+struct CityFactory<'b> {
+    pub name: String,
+    pub team_association: String,
+    pub association_label: String,
+    pub country: Association<'b, Country, CountryFactory>,
+}
+
+impl<'b> Default for CityFactory<'b> {
+    fn default() -> Self {
+        Self {
+            name: "Copenhagen".into(),
+            team_association: "teamfive".into(),
+            association_label: "thebest".into(),
+            country: Association::default(),
+        }
+    }
+}
+
+#[derive(Queryable, Clone)]
+struct VisitedCity {
+    pub user_id: i32,
+    pub city_id: i32,
+}
+
+
+#[derive(Clone, Factory)]
+#[factory(model = VisitedCity, table = crate::schema::visited_cities, no_id)]
+struct VisitedCityFactory<'b> {
+    pub user: Association<'b, User, UserFactory<'b>>,
+    pub city: Association<'b, City, CityFactory<'b>>,
+}
+
+impl<'b> Default for VisitedCityFactory<'b> {
+    fn default() -> Self {
+        Self {
+            user: Association::default(),
+            city: Association::default(),
+        }
+    }
+}
+
+fn main() {
+    let country = Country { id: 1, name: "Denmark".into() };
+
+    let user_factory = UserFactory::default();
+
+    let city_one = CityFactory::default()
+        .country(&country);
+    let city_two = CityFactory::default()
+        .name("Another city")
+        .country(&country);
+
+    let visited_city_one = VisitedCityFactory::default()
+        .user(user_factory.clone())
+        .city(city_one.clone());
+
+    let visited_city_two = VisitedCityFactory::default()
+        .user(user_factory.clone())
+        .city(city_two.clone());
+
+
+    assert_eq!(
+        visited_city_one.city.factory().unwrap().name,
+        city_one.name
+    );
+
+    assert_eq!(
+        visited_city_one.user.factory().unwrap().email,
+        user_factory.email
+    );
+
+
+    assert_eq!(
+        visited_city_two.city.factory().unwrap().name,
+        city_two.name
+    );
+
+    assert_eq!(
+        visited_city_two.user.factory().unwrap().email,
+        user_factory.email
+    );
+}

--- a/diesel-factories/tests/docs_setup_with_city_factory.rs
+++ b/diesel-factories/tests/docs_setup_with_city_factory.rs
@@ -29,6 +29,13 @@ mod schema {
             country_id -> Integer,
         }
     }
+
+    table! {
+        visited_cities (user_id, city_id) {
+            user_id -> Integer,
+            city_id -> Integer,
+        }
+    }
 }
 
 #[derive(Queryable, Clone)]
@@ -52,6 +59,39 @@ struct City {
 struct Country {
     pub id: i32,
     pub name: String,
+}
+
+#[derive(Queryable, Clone)]
+struct VisitedCity {
+    pub user_id: i32,
+    pub city_id: i32,
+}
+
+
+#[derive(Clone, Factory)]
+#[factory(
+model = User,
+table = crate::schema::users,
+connection = diesel::pg::PgConnection
+)]
+struct UserFactory<'a> {
+    pub name: &'a str,
+    pub age: i32,
+    pub country: std::option::Option<diesel_factories::Association<'a, Country, CountryFactory>>,
+    pub home_city: Option<diesel_factories::Association<'a, City, CityFactory<'a>>>,
+    pub current_city: Option<Association<'a, City, CityFactory<'a>>>,
+}
+
+impl<'a> Default for UserFactory<'a> {
+    fn default() -> Self {
+        Self {
+            name: "Bob",
+            age: 30,
+            country: None,
+            home_city: None,
+            current_city: None,
+        }
+    }
 }
 
 #[derive(Clone, Factory)]
@@ -80,6 +120,22 @@ impl<'a> Default for CityFactory<'a> {
         Self {
             name: String::new(),
             country: Association::default(),
+        }
+    }
+}
+
+#[derive(Clone, Factory)]
+#[factory(model = VisitedCity, table = crate::schema::visited_cities, no_id)]
+struct VisitedCityFactory<'b> {
+    pub user: Association<'b, User, UserFactory<'b>>,
+    pub city: Association<'b, City, CityFactory<'b>>,
+}
+
+impl<'b> Default for VisitedCityFactory<'b> {
+    fn default() -> Self {
+        Self {
+            user: Association::default(),
+            city: Association::default(),
         }
     }
 }

--- a/migrations/2021-11-22-030926_create_visited_cities/down.sql
+++ b/migrations/2021-11-22-030926_create_visited_cities/down.sql
@@ -1,0 +1,1 @@
+drop table visited_cities;

--- a/migrations/2021-11-22-030926_create_visited_cities/up.sql
+++ b/migrations/2021-11-22-030926_create_visited_cities/up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE visited_cities
+(
+    user_id int not null,
+    city_id int not null,
+    primary key (user_id, city_id)
+);


### PR DESCRIPTION
e.g. for when you have a join table with the two join columns as a combined primary key.