### PR TITLE
Diesel v2 + Map fields to model

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -4,6 +4,6 @@ set -e
 dropdb diesel_factories_test || true
 createdb diesel_factories_test || true
 
-cargo install diesel_cli --no-default-features --features postgres
+cargo install diesel_cli --no-default-features --features postgres || true
 
-diesel migration run --database-url postgresql://localhost:5432/diesel_factories_test
+diesel migration run --database-url postgresql://test:test@localhost:5432/diesel_factories_test

--- a/diesel-factories-code-gen/src/lib.rs
+++ b/diesel-factories-code-gen/src/lib.rs
@@ -268,17 +268,15 @@ impl Input {
         let connection_type = &self.connection;
         let table_path = &self.table;
         let id_name = &self.id_name;
-        
         let insert_code = if self.no_fields() {
 
             match self.map_fields  {
                 Some(_) => {
-                    let fields = self.fields.iter().map(|(name, _)| name);
                     
                     quote! {                    
                         diesel::insert_into(#table_path::table)
                         .default_values()
-                        .returning((#(#table_path::#fields),*))
+                        .returning(Self::Model::get_model_fields())
                         .get_result::<Self::Model>(con)
                         .expect("Insert of factory failed")
                     }
@@ -315,14 +313,11 @@ impl Input {
             
             match self.map_fields  {
                 Some(_) => {
-                    let fields = self.fields.iter().map(|(name, _)| name);
-
                     quote! {
                         let values = ( #(#values),* );
-                    
                         diesel::insert_into(#table_path::table)
                         .values(values)
-                        .returning((#(#table_path::#fields),*))
+                        .returning(Self::Model::get_model_fields())
                         .get_result::<Self::Model>(con)
                         .expect("Insert of factory failed")
                     }

--- a/diesel-factories-code-gen/src/lib.rs
+++ b/diesel-factories-code-gen/src/lib.rs
@@ -20,7 +20,6 @@ use quote::quote;
 use quote::{format_ident, ToTokens};
 use syn::spanned::Spanned;
 
-
 use syn::{
     parse::{Parse, ParseStream},
     parse_macro_input,
@@ -55,9 +54,7 @@ impl Parse for MapInput {
 
         let mut fields: Vec<Ident> = Vec::new();
 
-        let struct_attr::MapModel {
-            model,
-        } = struct_attr::MapModel::from_attributes(&attrs)?;
+        let struct_attr::MapModel { model } = struct_attr::MapModel::from_attributes(&attrs)?;
 
         for field in item_strut_fields {
             let field_span = field.span();
@@ -100,12 +97,11 @@ impl MapInput {
 }
 
 #[proc_macro_derive(MapModel, attributes(map_model))]
-pub fn derive_map_model(input: proc_macro::TokenStream) ->  proc_macro::TokenStream { 
+pub fn derive_map_model(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as MapInput);
     let tokens = quote! { #input };
     proc_macro::TokenStream::from(tokens)
 }
-
 
 mod struct_attr {
     use bae::FromAttributes;
@@ -246,7 +242,7 @@ impl Parse for Input {
             fields,
             associations,
             lifetime,
-            map_fields
+            map_fields,
         })
     }
 }
@@ -269,24 +265,22 @@ impl Input {
         let table_path = &self.table;
         let id_name = &self.id_name;
         let insert_code = if self.no_fields() {
-
-            match self.map_fields  {
+            match self.map_fields {
                 Some(_) => {
-                    
-                    quote! {                    
+                    quote! {
                         diesel::insert_into(#table_path::table)
                         .default_values()
                         .returning(Self::Model::get_model_fields())
                         .get_result::<Self::Model>(con)
                         .expect("Insert of factory failed")
                     }
-                },
+                }
                 _ => quote! {
                     diesel::insert_into(#table_path::table)
                     .default_values()
                     .get_result::<Self::Model>(con)
                     .expect("Insert of factory failed")
-                }
+                },
             }
         } else {
             let values = self.fields.iter().map(|(name, _)| {
@@ -310,8 +304,8 @@ impl Input {
                     }
                 },
             ));
-            
-            match self.map_fields  {
+
+            match self.map_fields {
                 Some(_) => {
                     quote! {
                         let values = ( #(#values),* );
@@ -321,7 +315,7 @@ impl Input {
                         .get_result::<Self::Model>(con)
                         .expect("Insert of factory failed")
                     }
-                },
+                }
                 _ => quote! {
                     let values = ( #(#values),* );
 
@@ -329,7 +323,7 @@ impl Input {
                     .values(values)
                     .get_result::<Self::Model>(con)
                     .expect("Insert of factory failed")
-                }
+                },
             }
         };
 

--- a/diesel-factories-code-gen/src/lib.rs
+++ b/diesel-factories-code-gen/src/lib.rs
@@ -88,7 +88,7 @@ impl MapInput {
 
         quote! {
             impl #ident {
-                fn get_model_fields() -> (#(#table::#fields),*) {
+                pub fn get_model_fields() -> (#(#table::#fields),*) {
                     (#(#table::#fields),*)
                 }
             };

--- a/diesel-factories-code-gen/src/lib.rs
+++ b/diesel-factories-code-gen/src/lib.rs
@@ -36,7 +36,7 @@ pub fn derive_factory(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 
 struct MapInput {
     ident: Ident,
-    model: Type,
+    table: Type,
     fields: Vec<Ident>,
 }
 
@@ -54,7 +54,7 @@ impl Parse for MapInput {
 
         let mut fields: Vec<Ident> = Vec::new();
 
-        let struct_attr::MapModel { model } = struct_attr::MapModel::from_attributes(&attrs)?;
+        let struct_attr::MapModel { table } = struct_attr::MapModel::from_attributes(&attrs)?;
 
         for field in item_strut_fields {
             let field_span = field.span();
@@ -69,7 +69,7 @@ impl Parse for MapInput {
         Ok(MapInput {
             fields,
             ident,
-            model,
+            table,
         })
     }
 }
@@ -84,12 +84,12 @@ impl MapInput {
     fn factory_trait_impl(&self) -> TokenStream {
         let ident = &self.ident;
         let fields = &self.fields;
-        let model = &self.model;
+        let table = &self.table;
 
         quote! {
             impl #ident {
-                fn get_model_fields() -> (#(#model::#fields),*) {
-                    (#(#model::#fields),*)
+                fn get_model_fields() -> (#(#table::#fields),*) {
+                    (#(#table::#fields),*)
                 }
             };
         }
@@ -119,7 +119,7 @@ mod struct_attr {
 
     #[derive(Debug, FromAttributes)]
     pub struct MapModel {
-        pub model: Type,
+        pub table: Type,
     }
 }
 

--- a/diesel-factories-code-gen/src/lib.rs
+++ b/diesel-factories-code-gen/src/lib.rs
@@ -232,7 +232,7 @@ impl Input {
                 type Id = #id_type;
                 type Connection = #connection_type;
 
-                fn insert(self, con: &Self::Connection) -> Self::Model {
+                fn insert(self, con: &mut Self::Connection) -> Self::Model {
                     use diesel::prelude::*;
                     #insert_code
                 }

--- a/diesel-factories/Cargo.toml
+++ b/diesel-factories/Cargo.toml
@@ -13,9 +13,9 @@ repository = "https://github.com/davidpdrsn/diesel-factories.git"
 version = "2.0.0"
 
 [dependencies]
-diesel = { version = "^1" }
+diesel = { version = "2" }
 diesel-factories-code-gen = { version = "2.0.0", path = "../diesel-factories-code-gen" }
 
 [dev_dependencies]
-diesel = { version = "^1.3", features = ["postgres", "network-address"] }
+diesel = { version = "2", features = ["postgres", "network-address"] }
 trybuild = "1.0.3"

--- a/diesel-factories/src/lib.rs
+++ b/diesel-factories/src/lib.rs
@@ -160,9 +160,9 @@
 //! #     let pg_host = env::var("POSTGRES_HOST").unwrap_or_else(|_| "localhost".to_string());
 //! #     let pg_port = env::var("POSTGRES_PORT").unwrap_or_else(|_| "5432".to_string());
 //! #     let pg_password = env::var("POSTGRES_PASSWORD").ok();
-//! #
+//! #     let pg_user = env::var("POSTGRES_USER").unwrap_or_else(|_| "test".to_string());
 //! #     let auth = if let Some(pg_password) = pg_password {
-//! #         format!("postgres:{}@", pg_password)
+//! #         format!("{}:{}@", pg_user, pg_password)
 //! #     } else {
 //! #         String::new()
 //! #     };

--- a/diesel-factories/src/lib.rs
+++ b/diesel-factories/src/lib.rs
@@ -99,55 +99,55 @@
 //!
 //! // Usage
 //! fn basic_usage() {
-//!     let con = establish_connection();
+//!     let mut con = establish_connection();
 //!
-//!     let city = CityFactory::default().insert(&con);
+//!     let city = CityFactory::default().insert(&mut con);
 //!     assert_eq!("Copenhagen", city.name);
 //!
-//!     let country = find_country_by_id(city.country_id, &con);
+//!     let country = find_country_by_id(city.country_id, &mut con);
 //!     assert_eq!("Denmark", country.name);
 //!
-//!     assert_eq!(1, count_cities(&con));
-//!     assert_eq!(1, count_countries(&con));
+//!     assert_eq!(1, count_cities(&mut con));
+//!     assert_eq!(1, count_countries(&mut con));
 //! }
 //!
 //! fn setting_fields() {
-//!     let con = establish_connection();
+//!     let mut con = establish_connection();
 //!
 //!     let city = CityFactory::default()
 //!         .name("Amsterdam")
 //!         .country(CountryFactory::default().name("Netherlands"))
-//!         .insert(&con);
+//!         .insert(&mut con);
 //!     assert_eq!("Amsterdam", city.name);
 //!
-//!     let country = find_country_by_id(city.country_id, &con);
+//!     let country = find_country_by_id(city.country_id, &mut con);
 //!     assert_eq!("Netherlands", country.name);
 //!
-//!     assert_eq!(1, count_cities(&con));
-//!     assert_eq!(1, count_countries(&con));
+//!     assert_eq!(1, count_cities(&mut con));
+//!     assert_eq!(1, count_countries(&mut con));
 //! }
 //!
 //! fn multiple_models_with_same_association() {
-//!     let con = establish_connection();
+//!     let mut con = establish_connection();
 //!
 //!     let netherlands = CountryFactory::default()
 //!         .name("Netherlands")
-//!         .insert(&con);
+//!         .insert(&mut con);
 //!
 //!     let amsterdam = CityFactory::default()
 //!         .name("Amsterdam")
 //!         .country(&netherlands)
-//!         .insert(&con);
+//!         .insert(&mut con);
 //!
 //!     let hague = CityFactory::default()
 //!         .name("The Hague")
 //!         .country(&netherlands)
-//!         .insert(&con);
+//!         .insert(&mut con);
 //!
 //!     assert_eq!(amsterdam.country_id, hague.country_id);
 //!
-//!     assert_eq!(2, count_cities(&con));
-//!     assert_eq!(1, count_countries(&con));
+//!     assert_eq!(2, count_cities(&mut con));
+//!     assert_eq!(1, count_countries(&mut con));
 //! }
 //! #
 //! # fn main() {
@@ -173,25 +173,25 @@
 //! #         host = pg_host,
 //! #         port = pg_port
 //! #     );
-//! #     let con = PgConnection::establish(&database_url).unwrap();
+//! #     let mut con = PgConnection::establish(&database_url).unwrap();
 //! #     con.begin_test_transaction().unwrap();
 //! #     con
 //! # }
 //!
 //! // Utility functions just for demo'ing
-//! fn count_cities(con: &PgConnection) -> i64 {
+//! fn count_cities(con: &mut PgConnection) -> i64 {
 //!     use crate::schema::cities;
 //!     use diesel::dsl::count_star;
 //!     cities::table.select(count_star()).first(con).unwrap()
 //! }
 //!
-//! fn count_countries(con: &PgConnection) -> i64 {
+//! fn count_countries(con: &mut PgConnection) -> i64 {
 //!     use crate::schema::countries;
 //!     use diesel::dsl::count_star;
 //!     countries::table.select(count_star()).first(con).unwrap()
 //! }
 //!
-//! fn find_country_by_id(input: i32, con: &PgConnection) -> Country {
+//! fn find_country_by_id(input: i32, con: &mut PgConnection) -> Country {
 //!     use crate::schema::countries::dsl::*;
 //!     countries
 //!         .filter(identity.eq(&input))
@@ -471,7 +471,7 @@ where
     F: Factory<Model = M> + Clone,
 {
     #[doc(hidden)]
-    pub fn insert_returning_id(&self, con: &F::Connection) -> F::Id {
+    pub fn insert_returning_id(&self, con: &mut F::Connection) -> F::Id {
         match self {
             Association::Model(model) => F::id_for_model(&model).clone(),
             Association::Factory(factory) => {
@@ -506,7 +506,7 @@ pub trait Factory: Clone {
     ///
     /// # Panics
     /// This will panic if the insert fails. Should be fine since you want panics early in tests.
-    fn insert(self, con: &Self::Connection) -> Self::Model;
+    fn insert(self, con: &mut Self::Connection) -> Self::Model;
 
     /// Get the primary key value for a model type.
     ///

--- a/diesel-factories/src/lib.rs
+++ b/diesel-factories/src/lib.rs
@@ -429,7 +429,7 @@
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-pub use diesel_factories_code_gen::{ Factory, MapModel };
+pub use diesel_factories_code_gen::{Factory, MapModel};
 
 /// A "belongs to" association that may or may not have been inserted yet.
 ///
@@ -481,7 +481,6 @@ where
         }
     }
 }
-
 
 /// A generic factory trait.
 ///

--- a/diesel-factories/src/lib.rs
+++ b/diesel-factories/src/lib.rs
@@ -429,7 +429,7 @@
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-pub use diesel_factories_code_gen::Factory;
+pub use diesel_factories_code_gen::{ Factory, MapModel };
 
 /// A "belongs to" association that may or may not have been inserted yet.
 ///
@@ -481,6 +481,7 @@ where
         }
     }
 }
+
 
 /// A generic factory trait.
 ///

--- a/diesel-factories/tests/compile_fail/foreign_key_name_on_non_association.stderr
+++ b/diesel-factories/tests/compile_fail/foreign_key_name_on_non_association.stderr
@@ -4,7 +4,7 @@ error: `#[factory]` attributes are only allowed on association fields
 39 |     #[factory(foreign_key_name = not_allowed_here)]
    |     ^
 
-error[E0599]: no method named `country` found for struct `UserFactory<'_>` in the current scope
+error[E0599]: no method named `country` found for struct `UserFactory` in the current scope
   --> $DIR/foreign_key_name_on_non_association.rs:75:10
    |
 38 | struct UserFactory<'a> {

--- a/diesel-factories/tests/compile_fail/foreign_key_name_on_non_association.stderr
+++ b/diesel-factories/tests/compile_fail/foreign_key_name_on_non_association.stderr
@@ -1,16 +1,19 @@
 error: `#[factory]` attributes are only allowed on association fields
-  --> $DIR/foreign_key_name_on_non_association.rs:39:5
+  --> tests/compile_fail/foreign_key_name_on_non_association.rs:39:5
    |
-39 |     #[factory(foreign_key_name = not_allowed_here)]
-   |     ^
+39 | /     #[factory(foreign_key_name = not_allowed_here)]
+40 | |     pub age: i32,
+   | |________________^
 
 error[E0599]: no method named `country` found for struct `UserFactory` in the current scope
-  --> $DIR/foreign_key_name_on_non_association.rs:75:10
+  --> tests/compile_fail/foreign_key_name_on_non_association.rs:75:10
    |
-38 | struct UserFactory<'a> {
-   | ---------------------- method `country` not found for this
+38 |   struct UserFactory<'a> {
+   |   ---------------------- method `country` not found for this struct
 ...
-75 |         .country(CountryFactory::default())
-   |          ^^^^^^^--------------------------- help: remove the arguments
-   |          |
-   |          field, not a method
+74 | /     UserFactory::default()
+75 | |         .country(CountryFactory::default())
+   | |         -^^^^^^^--------------------------- help: remove the arguments
+   | |         ||
+   | |_________|field, not a method
+   |

--- a/diesel-factories/tests/compile_pass/auto_pick_fields.rs
+++ b/diesel-factories/tests/compile_pass/auto_pick_fields.rs
@@ -1,0 +1,57 @@
+#![allow(proc_macro_derive_resolution_fallback, unused_imports)]
+
+#[macro_use]
+extern crate diesel;
+
+use diesel::{pg::PgConnection, prelude::*};
+use diesel_factories::{Association, Factory, MapModel};
+
+mod schema {
+    table! {
+        users (identity) {
+            identity -> Integer,
+            name -> Text,
+            last_name -> Text,
+            created_at -> Nullable<Timestamp>
+        }
+    }
+}
+
+#[derive(MapModel, Queryable, Clone)]
+#[map_model(
+    model = crate::schema::users,
+)]
+struct User {
+    pub identity: i32,
+    pub name: String,
+    pub last_name: String
+}
+
+#[derive(Clone, Factory)]
+#[factory(
+    model = User,
+    table = crate::schema::users,
+    connection = diesel::pg::PgConnection,
+    id_name = identity,
+    map_fields
+)]
+struct UserFactory {
+    pub identity: i32,
+    pub name: String,
+    pub last_name: String
+}
+
+impl Default for UserFactory {
+    fn default() -> Self {
+        Self {
+            identity: 32,
+            name: format!("test"),
+            last_name: format!("tset")
+        }
+    }
+}
+
+fn main() {
+    let f = UserFactory::default();
+    let d = f.name(format!("hello worrld"));
+}

--- a/diesel-factories/tests/compile_pass/map_fields.rs
+++ b/diesel-factories/tests/compile_pass/map_fields.rs
@@ -20,7 +20,7 @@ mod schema {
 
 #[derive(MapModel, Queryable, Clone)]
 #[map_model(
-    model = crate::schema::users,
+    table = crate::schema::users,
 )]
 struct User {
     pub identity: i32,

--- a/diesel-factories/tests/compile_pass/map_fields.rs
+++ b/diesel-factories/tests/compile_pass/map_fields.rs
@@ -11,6 +11,7 @@ mod schema {
         users (identity) {
             identity -> Integer,
             name -> Text,
+            age -> Integer,
             last_name -> Text,
             created_at -> Nullable<Timestamp>
         }
@@ -24,6 +25,7 @@ mod schema {
 struct User {
     pub identity: i32,
     pub name: String,
+    pub age: i32,
     pub last_name: String
 }
 
@@ -51,7 +53,4 @@ impl Default for UserFactory {
     }
 }
 
-fn main() {
-    let f = UserFactory::default();
-    let d = f.name(format!("hello worrld"));
-}
+fn main() {}

--- a/diesel-factories/tests/integration_test.rs
+++ b/diesel-factories/tests/integration_test.rs
@@ -174,7 +174,7 @@ fn setup() -> PgConnection {
     let pg_host = env::var("POSTGRES_HOST").unwrap_or_else(|_| "localhost".to_string());
     let pg_port = env::var("POSTGRES_PORT").unwrap_or_else(|_| "5432".to_string());
     let pg_password = env::var("POSTGRES_PASSWORD").ok();
-    let pg_user = env::var("POSTGRES_USER").unwrap_or_else(|_| "postgres".to_string());
+    let pg_user = env::var("POSTGRES_USER").unwrap_or_else(|_| "test".to_string());
 
     let auth = if let Some(pg_password) = pg_password {
         format!("{}:{}@", pg_user, pg_password)

--- a/diesel-factories/tests/integration_test.rs
+++ b/diesel-factories/tests/integration_test.rs
@@ -174,9 +174,10 @@ fn setup() -> PgConnection {
     let pg_host = env::var("POSTGRES_HOST").unwrap_or_else(|_| "localhost".to_string());
     let pg_port = env::var("POSTGRES_PORT").unwrap_or_else(|_| "5432".to_string());
     let pg_password = env::var("POSTGRES_PASSWORD").ok();
+    let pg_user = env::var("POSTGRES_USER").unwrap_or_else(|_| "postgres".to_string());
 
     let auth = if let Some(pg_password) = pg_password {
-        format!("postgres:{}@", pg_password)
+        format!("{}:{}@", pg_user, pg_password)
     } else {
         String::new()
     };

--- a/diesel-factories/tests/integration_test.rs
+++ b/diesel-factories/tests/integration_test.rs
@@ -128,42 +128,46 @@ impl<'b> Default for CityFactory<'b> {
 
 #[test]
 fn insert_one_user() {
-    let con = setup();
+    let mut con = setup();
 
-    let user = UserFactory::default().name("Alice").insert(&con);
+    let user = UserFactory::default().name("Alice").insert(&mut con);
 
     assert_eq!(user.name, "Alice");
     assert_eq!(user.age, 30);
-    assert_eq!(1, count_users(&con));
-    assert_eq!(0, count_countries(&con));
+    assert_eq!(1, count_users(&mut con));
+    assert_eq!(0, count_countries(&mut con));
 }
 
 #[test]
 fn overriding_country() {
-    let con = setup();
+    let mut con = setup();
 
     let bob = UserFactory::default()
         .country(Some(CountryFactory::default().name("USA")))
-        .insert(&con);
+        .insert(&mut con);
 
-    let country = find_country_by_id(bob.country_id.unwrap(), &con);
+    let country = find_country_by_id(bob.country_id.unwrap(), &mut con);
 
     assert_eq!("USA", country.name);
-    assert_eq!(1, count_users(&con));
-    assert_eq!(1, count_countries(&con));
+    assert_eq!(1, count_users(&mut con));
+    assert_eq!(1, count_countries(&mut con));
 }
 
 #[test]
 fn insert_two_users_sharing_country() {
-    let con = setup();
+    let mut con = setup();
 
-    let country = CountryFactory::default().insert(&con);
-    let bob = UserFactory::default().country(Some(&country)).insert(&con);
-    let alice = UserFactory::default().country(Some(&country)).insert(&con);
+    let country = CountryFactory::default().insert(&mut con);
+    let bob = UserFactory::default()
+        .country(Some(&country))
+        .insert(&mut con);
+    let alice = UserFactory::default()
+        .country(Some(&country))
+        .insert(&mut con);
 
     assert_eq!(bob.country_id, alice.country_id);
-    assert_eq!(2, count_users(&con));
-    assert_eq!(1, count_countries(&con));
+    assert_eq!(2, count_users(&mut con));
+    assert_eq!(1, count_countries(&mut con));
 }
 
 fn setup() -> PgConnection {
@@ -183,24 +187,24 @@ fn setup() -> PgConnection {
         host = pg_host,
         port = pg_port
     );
-    let con = PgConnection::establish(&database_url).unwrap();
+    let mut con = PgConnection::establish(&database_url).unwrap();
     con.begin_test_transaction().unwrap();
     con
 }
 
-fn count_users(con: &PgConnection) -> i64 {
+fn count_users(con: &mut PgConnection) -> i64 {
     use crate::schema::users;
     use diesel::dsl::count_star;
     users::table.select(count_star()).first(con).unwrap()
 }
 
-fn count_countries(con: &PgConnection) -> i64 {
+fn count_countries(con: &mut PgConnection) -> i64 {
     use crate::schema::countries;
     use diesel::dsl::count_star;
     countries::table.select(count_star()).first(con).unwrap()
 }
 
-fn find_country_by_id(input: i32, con: &PgConnection) -> Country {
+fn find_country_by_id(input: i32, con: &mut PgConnection) -> Country {
     use crate::schema::countries::dsl::*;
     countries
         .filter(identity.eq(&input))

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,17 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres:latest
+    restart: always
+    environment:
+      POSTGRES_USER: test
+      POSTGRES_PASSWORD: test
+      POSTGRES_DB: diesel_factories_test
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
+
+volumes:
+  pgdata:


### PR DESCRIPTION
Hey this is a PR that enable to factories to map the result of insert_into query to the fields defined in the Model, as it is described in the test map_field.rs